### PR TITLE
added missing options for actions.yml input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
   lane:
     description: "The lane that should be executed."
     required: true
+  options:
+    description: "The options that should be passed as arguments to the lane. The options should be serialized as a JSON object."
+    quired: false
   subdirectory:
     description: "The relative path from the project root directory to the subdirectory where the fastlane folder is located."
     required: false


### PR DESCRIPTION
Options is missing from `actions.yml`. I believe this is causing `options` be ignored when passed in as an argument to the job.