### PR TITLE
Drop deprecated setup-ruby action

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ Basic usage for executing a lane in the root directory without arguments.
 
 ```
 - uses: actions/checkout@v2
-- uses: actions/setup-ruby@v1
+- uses: ruby/setup-ruby@v1
   with:
-    ruby-version: '2.7.2'
+    ruby-version: 3.0
 - uses: maierj/fastlane-action@v2.0.1
   with:
     lane: 'beta'
@@ -59,9 +59,9 @@ fastlane beta option1:value1 option2:value2
 the workflow step should look like
 ```
 - uses: actions/checkout@v2
-- uses: actions/setup-ruby@v1
+- uses: ruby/setup-ruby@v1
   with:
-    ruby-version: '2.7.2'
+    ruby-version: 3.0
 - uses: maierj/fastlane-action@v2.0.1
   with:
     lane: 'beta'
@@ -72,9 +72,9 @@ Usage for executing a lane in a context where the fastlane folder is in a subdir
 
 ```
 - uses: actions/checkout@v2
-- uses: actions/setup-ruby@v1
+- uses: ruby/setup-ruby@v1
   with:
-    ruby-version: '2.7.2'
+    ruby-version: 3.0
 - uses: maierj/fastlane-action@v2.0.1
   with:
     lane: 'beta'
@@ -85,9 +85,9 @@ Speed up execution time of your workflow by specifying a custom directory where 
 
 ```
 - uses: actions/checkout@v2
-- uses: actions/setup-ruby@v1
+- uses: ruby/setup-ruby@v1
   with:
-    ruby-version: '2.7.2'
+    ruby-version: 3.0
 - uses: maierj/fastlane-action@v2.0.1
   with:
     lane: 'beta'


### PR DESCRIPTION
`actions/setup-ruby` is deprecated and `2.7.2` ruby version is not found.

> Run actions/setup-ruby@v1
>   with:
>     ruby-version: 2.7.2
> NOTE: This action is deprecated and is no longer maintained.
> Please, migrate to https://github.com/ruby/setup-ruby, which is being actively maintained.
> Error: Version 2.7.2 not found