### PR TITLE
Adds the env file option to the action

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ You can keep an eye on [this issue from the fastlane repo](https://github.com/fa
 
 ### `env`
 
-**Optional** 
+**Optional** If used, adds the env option to the fastlane command to use fastlane env files (see [Fastlane environment variables](https://docs.fastlane.tools/advanced/other/)).
 
 ## Example usage
 
@@ -97,6 +97,21 @@ Speed up execution time of your workflow by specifying a custom directory where 
     lane: 'beta'
     subdirectory: 'ios'
     bundle-install-path: 'vendor/bundle'
+```
+
+\
+Use the env option for fastlane env files:
+
+```
+- uses: actions/checkout@v2
+- uses: actions/setup-ruby@v1
+  with:
+    ruby-version: '2.7.2'
+- uses: maierj/fastlane-action@v2.0.1
+  with:
+    lane: beta
+    subdirectory: ios
+    env: staging
 ```
 ## Support & Limitations
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ You can keep an eye on [this issue from the fastlane repo](https://github.com/fa
 
 **Optional** The action tracks usage using Firebase by default (see [Tracking of usage statistics](https://github.com/maierj/fastlane-action#tracking-of-usage-statistics)). You can disable tracking by setting this input option to 'true'.
 
+### `env`
+
+**Optional** 
+
 ## Example usage
 
 Basic usage for executing a lane in the root directory without arguments.

--- a/README.md
+++ b/README.md
@@ -110,7 +110,6 @@ Use the env option for fastlane env files:
 - uses: maierj/fastlane-action@v2.0.1
   with:
     lane: beta
-    subdirectory: ios
     env: staging
 ```
 ## Support & Limitations

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,9 @@ inputs:
   options:
     description: "The options that should be passed as arguments to the lane. The options should be serialized as a JSON object."
     required: false
+  env:
+    description: "The env value that should be passes as an argument to the lane. The value should match to one of your fastlane env files."
+    required: false
 runs:
   using: node12
   main: main.js

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ inputs:
     description: "The options that should be passed as arguments to the lane. The options should be serialized as a JSON object."
     required: false
   env:
-    description: "The env value that should be passes as an argument to the lane. The value should match to one of your fastlane env files."
+    description: "The env value that should be passed as an argument to the lane. The value should match to one of your fastlane env files."
     required: false
 runs:
   using: node12

--- a/main.js
+++ b/main.js
@@ -7,6 +7,7 @@ function run() {
     try {
         const lane = core.getInput('lane', { required: true });
         const optionsInput = core.getInput('options', { required: false });
+        const env = core.getInput('env', { required: false });
         const subdirectory = core.getInput('subdirectory', { required: false });
         const bundleInstallPath = core.getInput('bundle-install-path', { required: false });
         const verbose = core.getInput('verbose', { required: false });
@@ -66,6 +67,10 @@ function run() {
 
         if (verbose === "true") {
             fastlaneOptions.push("--verbose");
+        }
+
+        if (env && env.length > 0) {
+            fastlaneOptions.push(`--env ${env}`);
         }
 
         let fastlaneExecutionResult;


### PR DESCRIPTION
Fastlane provides the option of having multiple env files for different deployment targets. This comes in quite handy when your app has a different bundle identifier depending on the environment (like staging or production) or when your app is a whitelabel solution where the built apps are delivered from different developer app store accounts.

I tested this change with my fork and my whitelabel app. Let me know if I need to provide anything else to make this PR accepted.