### PR TITLE
Update Node to v24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,5 +21,5 @@ inputs:
     description: "The env value that should be passed as an argument to the lane. The value should match to one of your fastlane env files."
     required: false
 runs:
-  using: node20
+  using: node24
   main: main.js


### PR DESCRIPTION
To fix the GitHub warning:
```
Node.js 20 actions are deprecated. 
The following actions are running on Node.js 20 and may not work as expected: 
maierj/fastlane-action@v3.1.0. 
Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. 
```

Until this PR is merged you can use it like this:
Replace
`uses: maierj/fastlane-action@v3.1.0`
with
 `uses: bobinrinder/fastlane-action@update-node-to-24`
or make your own fork of course.